### PR TITLE
remove figlet banner

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ var httpProxy = require('http-proxy');
 var express = require('express');
 var bodyParser = require('body-parser');
 var stream = require('stream');
-var figlet = require('figlet');
 
 var yargs = require('yargs')
     .usage('usage: $0 [options] <aws-es-cluster-endpoint>')
@@ -116,12 +115,6 @@ proxy.on('proxyReq', function (proxyReq, req, res, options) {
 });
 
 http.createServer(app).listen(PORT, BIND_ADDRESS);
-
-console.log(figlet.textSync('AWS ES Proxy!', {
-    font: 'Speed',
-    horizontalLayout: 'default',
-    verticalLayout: 'default'
-}));
 
 console.log('AWS ES cluster available at http://' + BIND_ADDRESS + ':' + PORT);
 console.log('Kibana available at http://' + BIND_ADDRESS + ':' + PORT + '/_plugin/kibana/');

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "aws-sdk": "^2.2.48",
     "body-parser": "^1.15.0",
     "express": "^4.13.4",
-    "figlet": "^1.1.1",
     "http-proxy": "^1.13.2",
     "yargs": "^4.6.0"
   }


### PR DESCRIPTION
The figlet banner makes sane output parsing impossible with any kind of log aggregation infrastructure in place.