### PR TITLE
Update for Heroku Compatibility

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node index.js

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ AWS ElasticSearch/Kibana Proxy to access your [AWS ES](https://aws.amazon.com/el
 
 This is the solution for accessing your cluster if you have [configured access policies](http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomain-configure-access-policies) for your ES domain
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/Swingline0/aws-es-kibana/tree/stable)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/santthosh/aws-es-kibana)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ AWS ElasticSearch/Kibana Proxy to access your [AWS ES](https://aws.amazon.com/el
 
 This is the solution for accessing your cluster if you have [configured access policies](http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomain-configure-access-policies) for your ES domain
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/Swingline0/aws-es-kibana/tree/stable&env[AWS_ACCESS_KEY_ID]=AWS_ACCESS_KEY_ID&env[AWS_SECRET_ACCESS_KEY]=AWS_SECRET_ACCESS_KEY&env[ENDPOINT]=my-endpoint.us-region.es.amazonaws.com&env[USER]=UsernameForHTTPAuth&env[PASSWORD]=PasswordForHTTPAuth)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/Swingline0/aws-es-kibana/tree/stable)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ AWS ElasticSearch/Kibana Proxy to access your [AWS ES](https://aws.amazon.com/el
 
 This is the solution for accessing your cluster if you have [configured access policies](http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomain-configure-access-policies) for your ES domain
 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/Swingline0/aws-es-kibana&env[AWS_ACCESS_KEY_ID]=AWS_ACCESS_KEY_ID&env[AWS_SECRET_ACCESS_KEY]=AWS_SECRET_ACCESS_KEY&env[ENDPOINT]=my-endpoint.us-region.es.amazonaws.com&env[USER]=UsernameForHTTPAuth&env[PASSWORD]=PasswordForHTTPAuth)
+
 ## Usage
 
 Install the npm module 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ AWS ElasticSearch/Kibana Proxy to access your [AWS ES](https://aws.amazon.com/el
 
 This is the solution for accessing your cluster if you have [configured access policies](http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomain-configure-access-policies) for your ES domain
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/Swingline0/aws-es-kibana&env[AWS_ACCESS_KEY_ID]=AWS_ACCESS_KEY_ID&env[AWS_SECRET_ACCESS_KEY]=AWS_SECRET_ACCESS_KEY&env[ENDPOINT]=my-endpoint.us-region.es.amazonaws.com&env[USER]=UsernameForHTTPAuth&env[PASSWORD]=PasswordForHTTPAuth)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/Swingline0/aws-es-kibana/tree/stable&env[AWS_ACCESS_KEY_ID]=AWS_ACCESS_KEY_ID&env[AWS_SECRET_ACCESS_KEY]=AWS_SECRET_ACCESS_KEY&env[ENDPOINT]=my-endpoint.us-region.es.amazonaws.com&env[USER]=UsernameForHTTPAuth&env[PASSWORD]=PasswordForHTTPAuth)
 
 ## Usage
 

--- a/app.json
+++ b/app.json
@@ -17,5 +17,5 @@
     "ENDPOINT" : "ES Endpoint (ex: my-endpoint.region-1.es.amazonaws.com)",
     "USER" : "HTTP Auth Username",
     "PASSWORD" : "HTTP Auth Password"
-  },
+  }
 }

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-es-kibana",
   "description": "A simple proxy to allow external access to your AWS Kibana instance",
-  "repository": "https://github.com/Swingline0/aws-es-kibana/tree/stable",
+  "repository": "https://github.com/santthosh/aws-es-kibana",
   "logo": "https://raw.githubusercontent.com/santthosh/aws-es-kibana/master/aws-es-kibana.png",
   "keywords": [
     "AWS",

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-es-kibana",
   "description": "A simple proxy to allow external access to your AWS Kibana instance",
-  "repository": "https://github.com/Swingline0/aws-es-kibana",
+  "repository": "https://github.com/Swingline0/aws-es-kibana/tree/stable",
   "logo": "https://raw.githubusercontent.com/santthosh/aws-es-kibana/master/aws-es-kibana.png",
   "keywords": [
     "AWS",

--- a/app.json
+++ b/app.json
@@ -1,0 +1,14 @@
+{
+  "name": "aws-es-kibana",
+  "description": "A simple proxy to allow external access to your AWS Kibana instance",
+  "repository": "https://github.com/Swingline0/aws-es-kibana",
+  "logo": "https://raw.githubusercontent.com/santthosh/aws-es-kibana/master/aws-es-kibana.png",
+  "keywords": [
+    "AWS",
+    "ES",
+    "ElasticSearch",
+    "Kibana",
+    "AWS ES Proxy",
+    "AWS ES Kibana"
+  ]
+}

--- a/app.json
+++ b/app.json
@@ -10,5 +10,12 @@
     "Kibana",
     "AWS ES Proxy",
     "AWS ES Kibana"
-  ]
+  ],
+  "env": {
+    "AWS_ACCESS_KEY_ID" : "Your AWS Access Key ID Here",
+    "AWS_SECRET_ACCESS_KEY" : "Your AWS Secret Key Here",
+    "ENDPOINT" : "ES Endpoint (ex: my-endpoint.region-1.es.amazonaws.com)",
+    "USER" : "HTTP Auth Username",
+    "PASSWORD" : "HTTP Auth Password"
+  },
 }

--- a/index.js
+++ b/index.js
@@ -13,31 +13,34 @@ var yargs = require('yargs')
     .usage('usage: $0 [options] <aws-es-cluster-endpoint>')
     .option('b', {
         alias: 'bind-address',
-        default: '127.0.0.1',
+        default: process.env.BIND_ADDRESS || '127.0.0.1',
         demand: false,
         describe: 'the ip address to bind to',
         type: 'string'
     })
     .option('p', {
         alias: 'port',
-        default: 9200,
+        default: process.env.PORT || 9200,
         demand: false,
         describe: 'the port to bind to',
         type: 'number'
     })
     .option('r', {
         alias: 'region',
+        default: process.env.REGION,
         demand: false,
         describe: 'the region of the Elasticsearch cluster',
         type: 'string'
     })
     .option('u', {
       alias: 'user',
+      default: process.env.USER,
       demand: false,
       describe: 'the username to access the proxy'
     })
     .option('a', {
       alias: 'password',
+      default: process.env.PASSWORD,
       demand: false,
       describe: 'the password to access the proxy'
     })
@@ -46,12 +49,12 @@ var yargs = require('yargs')
     .strict();
 var argv = yargs.argv;
 
-if (argv._.length !== 1) {
+var ENDPOINT = process.env.ENDPOINT || argv._[0];
+
+if (!ENDPOINT) {
     yargs.showHelp();
     process.exit(1);
 }
-
-var ENDPOINT = argv._[0];
 
 // Try to infer the region if it is not provided as an argument.
 var REGION = argv.r;
@@ -67,7 +70,7 @@ if (!REGION) {
     }
 }
 
-var TARGET = argv._[0];
+var TARGET = process.env.ENDPOINT || argv._[0];
 if (!TARGET.match(/^https?:\/\//)) {
     TARGET = 'https://' + TARGET;
 }

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var express = require('express');
 var bodyParser = require('body-parser');
 var stream = require('stream');
 var figlet = require('figlet');
+var basicAuth = require('basic-auth-connect');
 
 var yargs = require('yargs')
     .usage('usage: $0 [options] <aws-es-cluster-endpoint>')
@@ -29,6 +30,16 @@ var yargs = require('yargs')
         demand: false,
         describe: 'the region of the Elasticsearch cluster',
         type: 'string'
+    })
+    .option('u', {
+      alias: 'user',
+      demand: false,
+      describe: 'the username to access the proxy'
+    })
+    .option('a', {
+      alias: 'password',
+      demand: false,
+      describe: 'the password to access the proxy'
     })
     .help()
     .version()
@@ -84,6 +95,9 @@ var proxy = httpProxy.createProxyServer({
 });
 
 var app = express();
+if (argv.u && argv.a) {
+  app.use(basicAuth(argv.u, argv.a));
+}
 app.use(bodyParser.raw({type: '*/*'}));
 app.use(getcreds);
 app.use(function (req, res) {

--- a/index.js
+++ b/index.js
@@ -101,7 +101,6 @@ var app = express();
 if (argv.u && argv.a) {
   app.use(basicAuth(argv.u, argv.a));
 }
-app.get('/', function(req, res) { res.redirect('/_plugin/kibana/'); }
 app.use(bodyParser.raw({type: '*/*'}));
 app.use(getcreds);
 app.use(function (req, res) {

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var yargs = require('yargs')
     })
     .option('p', {
         alias: 'port',
-        default: process.env.PORT || 9200,
+        default: process.env.PROXY_PORT || 9200,
         demand: false,
         describe: 'the port to bind to',
         type: 'number'

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var yargs = require('yargs')
     .usage('usage: $0 [options] <aws-es-cluster-endpoint>')
     .option('b', {
         alias: 'bind-address',
-        default: process.env.BIND_ADDRESS || '127.0.0.1',
+        default: process.env.BIND_ADDRESS || '0.0.0.0',
         demand: false,
         describe: 'the ip address to bind to',
         type: 'string'

--- a/index.js
+++ b/index.js
@@ -101,6 +101,7 @@ var app = express();
 if (argv.u && argv.a) {
   app.use(basicAuth(argv.u, argv.a));
 }
+app.get('/', function(req, res) { res.redirect('/_plugin/kibana/'); }
 app.use(bodyParser.raw({type: '*/*'}));
 app.use(getcreds);
 app.use(function (req, res) {

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var yargs = require('yargs')
     })
     .option('p', {
         alias: 'port',
-        default: process.env.PROXY_PORT || 9200,
+        default: process.env.PORT || 9200,
         demand: false,
         describe: 'the port to bind to',
         type: 'number'

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "engines": {
+    "node": "6.3.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/santthosh/aws-es-kibana.git"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "aws": "0.0.3-2",
     "aws-sdk": "^2.2.48",
+    "basic-auth-connect": "^1.0.0",
     "body-parser": "^1.15.0",
     "express": "^4.13.4",
     "figlet": "^1.1.1",


### PR DESCRIPTION
Hey there, awesome work on this project. Very handy.

I had a need come up to deploy this over to Heroku for more public access. I wanted to roll in some basic HTTP authentication too so it wouldn't be totally public. The high level changes here are:

- Allow all config vars to be references from `process.env` (Including the endpoint)
- Add `Procfile` for Heroku
- Add `app.json` to allow for one-click "Deploy to Heroku"
- Add "Deploy to Heroku" button to Heroku

Because the "Deploy to Heroku" feature requires a url to the repo, it would be difficult to test this without first merging. You can test it on the feature branch in my fork located here:

https://github.com/Swingline0/aws-es-kibana/tree/stable 

Let me know if you'd like to see any tweaks on this.
Thanks again!