### PR TITLE
Fix empty req body for some Elasticsearch clients

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ var proxy = httpProxy.createProxyServer({
 });
 
 var app = express();
-app.use(bodyParser.raw({type: '*/*'}));
+app.use(bodyParser.raw({type: function() { return true; }}));
 app.use(getcreds);
 app.use(function (req, res) {
     var bufferStream;


### PR DESCRIPTION
Some specific Elasticsearch clients (in my case is PHP one) don't provide a Content-Type header by default, which makes the body-parser failed to read the body and consequently causes following error:

    {
        "message":"The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details......"
    }

May be also related to this: https://gist.github.com/nakedible-p/ad95dfb1c16e75af1ad5#gistcomment-1757205