### PR TITLE
Add limit option to controls the maximum request body size

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,12 @@ var yargs = require('yargs')
       demand: false,
       describe: 'remove figlet banner'
     })
+    .option('l', {
+      alias: 'limit',
+      default: '100kb',
+      demand: false,
+      describe: 'controls the maximum request body size'
+    })
     .help()
     .version()
     .strict();
@@ -109,7 +115,7 @@ app.use(compress());
 if (argv.u && argv.a) {
   app.use(basicAuth(argv.u, argv.a));
 }
-app.use(bodyParser.raw({type: function() { return true; }}));
+app.use(bodyParser.raw({type: function() { return true; }, limit: argv.l}));
 app.use(getCredentials);
 app.use(function (req, res) {
     var bufferStream;


### PR DESCRIPTION
Since the [logstash-amazon-es-output plugin](https://github.com/awslabs/logstash-output-amazon_es) [desn't support logstash 5](https://github.com/awslabs/logstash-output-amazon_es/issues/42), we are temporary using this proxy to push logstash events to elasticsearch. 

The [body-parser](https://github.com/expressjs/body-parser#limit-1) accept  maximum request body size == `100kb` be default. This PR let's configure the maximum request body size.