### PR TITLE
Updated node version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "engines": {
-    "node": "6.3.0"
+    "node": ">=6.3.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This module works perfectly with node 7, but refuses to install (using yarn) because node 7 is not included  in the `engines.node` range.
I've updated the range to `"node": ">=6.3.0"` (assuming there's a specific reason to no support node <6.3.0)