### PR TITLE
Drop protocol from cluster >> README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Set AWS credentials
     export AWS_ACCESS_KEY_ID=XXXXXXXXXXXXXXXXXXX
     export AWS_SECRET_ACCESS_KEY=XXXXXXXXXXXXXXXXXXX
 
-Run the proxy
+Run the proxy (do not include the `http` or `https` from your `cluster-endpoint` or the proxy won't function)
 
     aws-es-kibana <cluster-endpoint>
 


### PR DESCRIPTION
Thanks for the proxy - I should have realised this sooner but took a little digging before I discovered you need to drop protocol from `cluster-endpoint`.