### PR TITLE
Add support for health endpoint

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,6 +16,7 @@
     "AWS_SECRET_ACCESS_KEY" : "Your AWS Secret Key Here",
     "ENDPOINT" : "ES Endpoint (ex: my-endpoint.region-1.es.amazonaws.com)",
     "USER" : "HTTP Auth Username",
-    "PASSWORD" : "HTTP Auth Password"
+    "PASSWORD" : "HTTP Auth Password",
+    "HEALTH_PATH" : "Optional HTTP Path for health check (ex: '/health')"
   }
 }

--- a/index.js
+++ b/index.js
@@ -51,6 +51,13 @@ var yargs = require('yargs')
       demand: false,
       describe: 'remove figlet banner'
     })
+    .option('H', {
+        alias: 'health-path',
+        default: process.env.HEALTH_PATH,
+        demand: false,
+        describe: 'URI path for health check',
+        type: 'string'
+    })
     .help()
     .version()
     .strict();
@@ -111,6 +118,14 @@ if (argv.u && argv.a) {
 }
 app.use(bodyParser.raw({type: function() { return true; }}));
 app.use(getCredentials);
+
+if (argv.H) {
+    app.get(argv.H, function (req, res) {
+        res.setHeader('Content-Type', 'text/plain');
+        res.send('ok');
+    });
+}
+
 app.use(function (req, res) {
     var bufferStream;
     if (Buffer.isBuffer(req.body)) {
@@ -158,3 +173,6 @@ if(!argv.s) {
 
 console.log('AWS ES cluster available at http://' + BIND_ADDRESS + ':' + PORT);
 console.log('Kibana available at http://' + BIND_ADDRESS + ':' + PORT + '/_plugin/kibana/');
+if (argv.H) {
+    console.log('Health endpoint enabled at http://' + BIND_ADDRESS + ':' + PORT + argv.H);
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "aws-es-kibana": "index.js"
   },
   "dependencies": {
-    "aws-sdk": "^2.5.1",
+    "aws-sdk": "^2.48.0",
     "basic-auth-connect": "^1.0.0",
     "body-parser": "^1.15.2",
     "compression": "^1.6.2",


### PR DESCRIPTION
This change adds an optional health endpoint path which will return a 200 status code.
This is useful for environments where you might be deploying this as a Docker service behind
a service discovery mechanism or load balancer which has a health check.

You can set either the `-H` flag or specify the `HEALTH_PATH` environment variable as in this example:

```
HEALTH_PATH=/health aws-es-kibana
```

When specified, you’ll see this additional console output:

```
Health endpoint enabled at http://127.0.0.1:9200/health
```

Thanks to @williamhaley for the assist!

I also had to update the AWS-SDK to add support for ECS task IAM roles.