### PR TITLE
Added limit argument to set request limit in body parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,12 @@ var yargs = require('yargs')
       demand: false,
       describe: 'remove figlet banner'
     })
+    .option('l', {
+      alias: 'limit',
+      default: process.env.LIMIT || '1kb',  
+      demand: false,
+      describe: 'request limit'
+    })
     .help()
     .version()
     .strict();
@@ -84,6 +90,7 @@ if (!TARGET.match(/^https?:\/\//)) {
 
 var BIND_ADDRESS = argv.b;
 var PORT = argv.p;
+var REQ_LIMIT = argv.l;
 
 var credentials;
 var chain = new AWS.CredentialProviderChain();
@@ -109,7 +116,7 @@ app.use(compress());
 if (argv.u && argv.a) {
   app.use(basicAuth(argv.u, argv.a));
 }
-app.use(bodyParser.raw({type: function() { return true; }}));
+app.use(bodyParser.raw({limit: REQ_LIMIT, type: function() { return true; }}));
 app.use(getCredentials);
 app.use(function (req, res) {
     var bufferStream;


### PR DESCRIPTION
**Gist:**
`body-parser` defaults its request body limit to 1kb. I added a command line flag (`-l`) to accept a string that will overwrite the default request body limit.

For example:
`aws-es-kibana <ES_HOST> -l=5mb`