### PR TITLE
Security Key Invalid Error #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ Run the proxy
 
     aws-es-kibana <cluster-endpoint>
 
+Where cluster-endpoint can be either a URL (i.e. https://search-xxxxx.us-west2.es.amazonaws.com) or a hostname (i.e. search-xxxxx.us-west2.es.amazonaws.com). 
 Alternatively, you can set the _AWS_PROFILE_ environment variable
 
     AWS_PROFILE=myprofile aws-es-kibana <cluster-endpoint>
     
-Example 
+Example with hostname as cluster-endpoint:
 
 ![aws-es-kibana](https://raw.githubusercontent.com/santthosh/aws-es-kibana/master/aws-es-kibana.png)
 

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ proxy.on('proxyReq', function (proxyReq, req) {
     if (Buffer.isBuffer(req.body)) request.body = req.body;
     if (!request.headers) request.headers = {};
     request.headers['presigned-expires'] = false;
-    request.headers['Host'] = ENDPOINT;
+    request.headers['Host'] = endpoint.hostname;
 
     var signer = new AWS.Signers.V4(request, 'es');
     signer.addAuthorization(credentials, new Date());


### PR DESCRIPTION
Security Key Invalid Errors do not happen anymore because 
aws-es-kibana now supports both the URL or hostname syntax
for the cluster-endpoint
