### PR TITLE
Increased the default response limit 

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ var yargs = require('yargs')
     })
     .option('l', {
       alias: 'limit',
-      default: process.env.LIMIT || '1kb',  
+      default: process.env.LIMIT || '10000kb',  
       demand: false,
       describe: 'request limit'
     })


### PR DESCRIPTION
Increased the default response limit to allow people to run the docker image without having to push overrides into the JS. This is by no means optimal but working against current AWS ES very nicely.

I see there are quite a few people trying to use this to interact with AWS ES - This would fix the issue for those just wanting to docker build -> docker run. Works nicely for me although by no means is this necessarily a safe or reasonable limit to put into place. 