### PR TITLE
Making it more friendly to Elastic Beanstalk

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,13 +35,13 @@ var yargs = require('yargs')
     })
     .option('u', {
       alias: 'user',
-      default: process.env.USER,
+      default: process.env.AUTH_USER ||process.env.USER,
       demand: false,
       describe: 'the username to access the proxy'
     })
     .option('a', {
       alias: 'password',
-      default: process.env.PASSWORD,
+      default: process.env.AUTH_PASSWORD || process.env.PASSWORD,
       demand: false,
       describe: 'the password to access the proxy'
     })


### PR DESCRIPTION
Elastic Beanstalk overwrites USER envar with `ec2-user`. This change preserves existing behavior and adds more specific envars for use with EB.