### PR TITLE
Restore basic auth for endpoints other than health

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,10 @@ if (argv.H) {
     });
 }
 
+if (argv.u && argv.a) {
+  app.use(basicAuth(argv.u, argv.a));
+}
+
 app.use(function (req, res) {
     var bufferStream;
     if (Buffer.isBuffer(req.body)) {


### PR DESCRIPTION
Using 

https://github.com/santthosh/aws-es-kibana/blob/900ec1c59c628d752906fe4206bd9ec3e59b403c/index.js#L130-L133

has no effect on the proxy whatsoever (the auth isn't meant to be sent to AWS, but instead to restrict access to the kibana panel).

If you want to enable basic auth for endpoints other than healthcheck, it's enough to use the middleware *after* declaring the health route.

```js
if (argv.H) {
    app.get(argv.H, function (req, res) {
        res.setHeader('Content-Type', 'text/plain');
        res.send('ok');
    });
}

if (argv.u && argv.a) {
  app.use(basicAuth(argv.u, argv.a));
}
```