### PR TITLE
Only check for .aws/credentials updates, if a profile is used

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,7 +208,9 @@ if (argv.H) {
     console.log('Health endpoint enabled at http://' + BIND_ADDRESS + ':' + PORT + argv.H);
 }
 
-fs.watch(`${homedir}/.aws/credentials`, (eventType, filename) => {
-    credentials = new AWS.SharedIniFileCredentials({profile: PROFILE});
-    AWS.config.credentials = credentials;
-});
+if (PROFILE) {
+    fs.watch(`${homedir}/.aws/credentials`, (eventType, filename) => {
+        credentials = new AWS.SharedIniFileCredentials({profile: PROFILE});
+        AWS.config.credentials = credentials;
+    });
+}


### PR DESCRIPTION
Hi,
I've added a check if an AWS Profile is set. Otherwise you get an error in environments, where no .aws/credentials file exists (e.g. when you only use the AWS environment variables).