### PR TITLE
fix Error: watch /root/.aws/credentials ENOENT in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN chown aws-es-kibana:aws-es-kibana /app
 COPY package.json /app
 RUN npm install
 COPY index.js /app
+RUN mkdir /root/.aws && cd /root/.aws && touch credentials
 
 EXPOSE 9200
 


### PR DESCRIPTION
These errors come out when i use default docker images.

ubuntu@ip-10-0-2-43:~/kibana/config$ docker run -it santthosh/aws-es-kibana search-ezmcloud-es-dev-cpb37dt4f5rzdlzy.us-east-2.es.amazonaws.com
__________       _________    _________________    ________                            ______
___    |_ |     / /_  ___/    ___  ____/_  ___/    ___  __ \________________  ______  ____  /
__  /| |_ | /| / /_____ \     __  __/  _____ \     __  /_/ /_  ___/  __ \_  |/_/_  / / /_  /
_  ___ |_ |/ |/ / ____/ /     _  /___  ____/ /     _  ____/_  /   / /_/ /_>  < _  /_/ / /_/
/_/  |_|___/|__/  /____/      /_____/  /____/      /_/     /_/    \____//_/|_| _\__, / (_)
                                                                               /____/
AWS ES cluster available at http://127.0.0.1:9200
Kibana available at http://127.0.0.1:9200/_plugin/kibana/
fs.js:1384
    throw error;
    ^

**Error: watch /root/.aws/credentials ENOENT
    at _errnoException (util.js:992:11)
    at FSWatcher.start (fs.js:1382:19)
    at Object.fs.watch (fs.js:1408:11)
    at Object.<anonymous> (/app/index.js:211:4)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Function.Module.runMain (module.js:693:10)**

So i had modified DOCKER file to avoid these errors. The docker image will be much more convenient after merging this PR, Please review and update default docker image.
